### PR TITLE
python3 fix for bulk change

### DIFF
--- a/src/fobi/admin.py
+++ b/src/fobi/admin.py
@@ -470,7 +470,7 @@ class BasePluginModelAdmin(admin.ModelAdmin):
                 groups_action = form.cleaned_data.pop('groups_action')
                 cleaned_data = dict(
                     (key, val)
-                    for (key, val) in form.cleaned_data.iteritems()
+                    for (key, val) in form.cleaned_data.items()
                     if val is not None
                 )
 


### PR DESCRIPTION
iteritems is gone, replaced by dict.items()
Might break backwards compatibility...
https://wiki.python.org/moin/Python3.0 :
Removed dict.iteritems(), dict.iterkeys(), and dict.itervalues().
Instead: use dict.items(), dict.keys(), and dict.values() respectively.